### PR TITLE
Add Mojo coordinates to events.

### DIFF
--- a/src/main/java/io/takari/maven/timeline/Event.java
+++ b/src/main/java/io/takari/maven/timeline/Event.java
@@ -9,15 +9,28 @@ public class Event {
     private final long trackNum;
     private final String groupId;
     private final String artifactId;
+    private final String mojoGroupId;
+    private final String mojoArtifactId;
     private final String phase;
     private final String goal;
     private final String id;
 
-    public Event(long trackNum, long start, String groupId, String artifactId, String phase, String goal, String id) {
+    public Event(
+            long trackNum,
+            long start,
+            String groupId,
+            String artifactId,
+            String mojoGroupId,
+            String mojoArtifactId,
+            String phase,
+            String goal,
+            String id) {
         this.start = start;
         this.trackNum = trackNum;
         this.groupId = groupId;
         this.artifactId = artifactId;
+        this.mojoGroupId = mojoGroupId;
+        this.mojoArtifactId = mojoArtifactId;
         this.phase = phase;
         this.goal = goal;
         this.id = id;

--- a/src/main/resources/timeline/app.js
+++ b/src/main/resources/timeline/app.js
@@ -103,6 +103,8 @@ function TimeLineApp() {
 
     appendCssClassToggle(controlsContainer, "groupId", false);
     appendCssClassToggle(controlsContainer, "artifactId", true);
+    appendCssClassToggle(controlsContainer, "mojoGroupId", false);
+    appendCssClassToggle(controlsContainer, "mojoArtifactId", false);
     appendCssClassToggle(controlsContainer, "goal", false);
     appendCssClassToggle(controlsContainer, "phase", true);
     appendCssClassToggle(controlsContainer, "id", false);

--- a/src/main/resources/timeline/timeline.js
+++ b/src/main/resources/timeline/timeline.js
@@ -59,8 +59,9 @@ function TimeLine(timelineData) {
 
   function description(event) {
     return event.groupId + ":" +
-      event.artifactId + ":" +
-      event.artifactId + ":" +
+      event.artifactId + " | " +
+      event.mojoGroupId + ":" +
+      event.mojoArtifactId + " | " +
       event.phase + ":" +
       event.goal + ":" +
       event.id + "(" +
@@ -101,6 +102,8 @@ function TimeLine(timelineData) {
       container.appendChild(div);
       addProperty(div, event, "groupId");
       addProperty(div, event, "artifactId");
+      addProperty(div, event, "mojoGroupId");
+      addProperty(div, event, "mojoArtifactId");
       addProperty(div, event, "phase");
       addProperty(div, event, "goal");
       if (event.id.indexOf("default-" != 0)) {


### PR DESCRIPTION
Hi!

In huge projects with many plugins different events become hard to distinguish (as the only part in the event attributes which differs is execution id, which frequently is an implicit thing). Assigning an explicit, unique and distinguishable execution ID for each execution of each plugin is a pain, so instead I've added mojo coordinates to each event to get a better picture like this:

<img width="1279" height="598" alt="timeline-new" src="https://github.com/user-attachments/assets/963090ea-5c1c-4bbf-87f1-f0e3723de45a" />

At the scale (~100 modules, tens of plugins) that makes the result much more readable, and I believe that this would be good enough even for smaller projects.

Also, I've fixed a [duplicate](https://github.com/takari/maven-timeline/blob/master/src/main/resources/timeline/timeline.js#L62-L63) `artifactId` (`..:artifactId:artifactId:...`) for each event in the timeline, which seems to be a typo.